### PR TITLE
v0.6.1 — normalization patch: the normalizer catches what you reported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# macOS Finder metadata. Written into any folder Finder opens, including this
+# one - not part of the project and never wanted in a commit.
+.DS_Store
+._*

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -55,9 +55,9 @@ A third class — **reference detectors**, comparing the library against an exte
 
 Punctuation stripping and diacritic folding are **not implemented anywhere**, and the `&`/`and` rule exists **only on artists**. Earlier drafts claimed punctuation stripping was part of the pipeline; it never was. Several open issues trace directly to these three gaps (§3.3). Each rule that *does* exist was driven by a real user report, not speculation. Two principles worth preserving:
 
-- Normalization changes are the highest-risk edits in the codebase — they silently change what groups with what. Hence the planned merge contract (§4.1).
-- The canonical MUST-NOT-merge example: **Elvis Costello vs. Elvis Costello & The Attractions** are different credits, correctly distinct. Any normalization change that merges them is wrong.
-- A dormant future guard exists conceptually for title normalization: numeric-punctuation titles like *3.15.20* must not normalize to "31520". Not yet enforced anywhere; encode it in the merge contract when title normalization is touched.
+- Normalization changes are the highest-risk edits in the codebase — they silently change what groups with what. Hence the merge contract, `tests/merge-contract.js` (§4.1.1) — **built as of 2026-08-01**. Add cases there before changing behaviour here.
+- The canonical MUST-NOT-merge example: **Elvis Costello vs. Elvis Costello & The Attractions** are different credits, correctly distinct. Any normalization change that merges them is wrong. Now enforced.
+- The title guard — numeric-punctuation titles like *3.15.20* must not normalize to "31520" — **is now enforced**, but not as a pair. It could not be: asserting that `3.15.20` and `31520` stay unmerged proves nothing, because the year rule rewrites `31520` to `3` and the two differ no matter what punctuation does. It lives in the contract's `KEY_MUST_NOT_BE` list as an assertion about the key itself. This was found by injecting the exact mistake the guard exists to catch and watching the pair form pass.
 
 ### 1.8 Git/release conventions (and why)
 
@@ -177,6 +177,8 @@ Theme: "the normalizer catches what you reported."
 | 6 | Apostrophes U+00B4, U+0060, U+02BC | 0 | +5 | #12 |
 | 7 | Bracket/paren container canonicalization | — | +1 | #17 general class |
 | 8 | Android file-input `accept` fix | — | — | #5 |
+| 9 | Year allowed between dash and keyword | — | +4 | see 4.1.3 |
+| 10 | Year suffix requires its keyword | — | **−6 false** | see 4.1.3 |
 | | **all combined** | **38→49** | **400→561** | |
 
 All 11 new artist groups and the top 40 new track groups were inspected by hand; no false positive was found. Notes:
@@ -257,6 +259,25 @@ Required behaviour, following §1.9:
 **Decision (2026-08-01): diacritic folding stays in v0.6.1, chip included.** The alternative considered and rejected was deferring folding to v0.7 to keep v0.6.1 purely mechanical — every other item in the release is a one-line normalizer edit, and this one pulls in rendering work. Rejected because folding is the second-largest detection win in the release (+8 artist, +24 track) and splitting it from the chip would ship the unreadable-card problem on purpose. v0.6.1 therefore contains exactly one piece of UI work; expect it in review.
 
 Scope note: this is Romanian/Turkish cedilla-vs-comma-below in practice, but the rule is written on perceptual grounds rather than per-script so it generalises. It is small — the reveal-chip renderer already exists and is reused. Measurement caveat for whoever picks this up: an early pass put the track-side count at 2, but both were artifacts of a crude heuristic (it tested whether *every row* contained any mark, not whether the *differing* character was mark-vs-mark, so `À Mon Âme` vs `A Mon Âme` was misbinned). Treat the affected population as artist-side only until re-measured with a positional comparison.
+
+#### 4.1.3 Items 9 and 10 — two suffix bugs found by the merge contract
+
+Neither was reported by a user. Both surfaced on 2026-08-01 while writing MUST_MERGE cases for behaviour assumed to already work, which is the merge contract earning its place before a single scoped item had been built. Added to v0.6.1 by decision the same day.
+
+**Item 9 — dangling separator.** `Midtown - 2023 Remaster` normalized to `midtown -`, so it grouped with nothing. The dash rule required its keyword *immediately* after the dash, so with a year in between it did not fire; the year rule then stripped `2023 Remaster` and abandoned the separator. This is the standard Spotify shape and exactly what discussion #7 raised. Fix: allow an optional `\d{4}` between the dash and the keyword, in the track *and* album normalizers. On the issue-#11 export: +4 groups, and track keys ending in an orphaned separator fall from 20 to 8 (the remainder are legitimate — Isis `-`, Mew `+ -`, a Morse-code artist).
+
+**Item 10 — over-eager year strip.** The trailing-year rule made its keyword optional, so it deleted *any* trailing four-digit run. This did real damage: it was not merely failing to group, it was **fabricating cards**. Every wholly numeric title normalized to the empty string and collapsed together:
+
+```
+"1991"(55)  | "1983"(1)                                     <- distinct tracks, merged
+"0001"(2)   | "0002"(2)  | "0003"(2) | "0004"(2)            <- distinct tracks, merged
+"80186"(1)  | "80286"(1) | ... | "80686"(1)                 <- \d{4} matched inside a 5-digit title
+"19-2000"   -> "19-"      "555-5555" -> "555-"              <- titles mangled
+```
+
+Fix: make the keyword required. On the export this removes **6 false-positive groups**. That is the reason items 9 and 10 read as `+4 / −6` in the table above: the headline count drops, and detection quality strictly improves. Do not read the −6 as a regression.
+
+Both fixes are guarded going forward — item 9 by MUST_MERGE cases, item 10 by MUST_NOT_MERGE cases including `1991`/`1983` and `80186`/`80286`.
 
 ### 4.2 v0.7.0 — pattern-detector release (scoped, not built)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -161,11 +161,24 @@ Real typos exist in that set but are buried by design: they are *rare* (`Citzen 
 
 ## 4. Roadmap
 
-### 4.1 v0.6.1 — normalization patch (scoped, not built)
+### 4.1 v0.6.1 — normalization patch (BUILT 2026-08-01, unreleased)
 
 Theme: "the normalizer catches what you reported."
 
-**Scope validated 2026-08-01** against the 380,877-scrobble export attached to issue #11 (§5.2), using a Node harness that replicated the three shipped normalizers verbatim. Baseline on that library, at the thresholds as shipped (artist ≥10 plays, track ≥3): **38 artist issues, 400 track issues**. Each change measured in isolation:
+All ten items are implemented on branch `normalization-patch`, one commit each, each measured before it landed. Nothing is released yet.
+
+**Measured outcome**, working tree vs. `main`, at the thresholds as shipped (artist ≥10 plays, album ≥5, track ≥3):
+
+| | scoblitz (160,742 scrobbles) | Maeldun (380,877 scrobbles) |
+|---|---|---|
+| Artist | 46 → **49** | 38 → **49** |
+| Album | 98 → **132** | 31 → **55** |
+| Track | 994 → **1201** | 400 → **559** |
+| Groups genuinely dropped | **0** | 6, all intentional |
+
+Every disappearing group was classified rather than counted: scoblitz 42 gone / 42 absorbed into larger groups / 0 dropped; Maeldun 10 gone / 4 absorbed / 6 dropped, those six being the numeric-title false positives item 10 exists to remove. Dismissal orphaning stayed negligible on both (§5.1).
+
+The per-item table below is the **pre-implementation estimate**, kept for attribution — it shows which change is responsible for what. Its figures were measured in isolation against Maeldun only, on a Node harness that copied the normalizers rather than reading them, and the combined row understates the shipped result because it predates items 9/10 and never covered albums. Trust the measured table above; use this one to attribute.
 
 | # | Change | Artist | Track | Closes |
 |---|---|:---:|:---:|---|
@@ -179,11 +192,11 @@ Theme: "the normalizer catches what you reported."
 | 8 | Android file-input `accept` fix | — | — | #5 |
 | 9 | Year allowed between dash and keyword | — | +4 | see 4.1.3 |
 | 10 | Year suffix requires its keyword | — | **−6 false** | see 4.1.3 |
-| | **all combined** | **38→49** | **400→561** | |
+| | *estimated combined* | *38→49* | *400→561* | |
 
 All 11 new artist groups and the top 40 new track groups were inspected by hand; no false positive was found. Notes:
 
-1. **Merge contract** — a checked-in, Node-runnable test file: MUST-merge pairs, MUST-NOT-merge pairs (Elvis Costello & The Attractions enshrined), documented KNOWN_MISS class, and a dormant title-guard section (*3.15.20* ≠ "31520"). **Build this first**; normalization changes land only after it passes. Nothing of the kind exists yet — see §4.1.1.
+1. **Merge contract** — `tests/merge-contract.js`, built first as planned. Now at **64 assertions** with 2 known misses (the typo cases #15/#16, which have no viable detector). It found items 9 and 10 before any scoped change was written — see §4.1.1 and §4.1.3.
 2. Routes `feat.`/`ft.` pairs into ordinary track-variation cards. Accepted deliberately as a first step to *surface* the issue, deferring the separate "Multiple Artists" category (disc. #4) to v0.7 once §5.3 is settled.
 3. **Period must map to a space, not to deletion.** This is exactly what preserves the §1.7 title guard: `3.15.20` → `3 15 20`, never `31520`. Verified.
 4. The dominant win on this library is Romanian cedilla-vs-comma-below (`ş` U+015F vs `ș` U+0219); `Ștefan Hrușcă` is currently split three ways at 61/16/15 plays and NFD folding reconciles all three. **This item carries a hard dependency — see 4.1.2. Folding must not ship without the confusable-character chip.**

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -277,7 +277,19 @@ Neither was reported by a user. Both surfaced on 2026-08-01 while writing MUST_M
 
 Fix: make the keyword required. On the export this removes **6 false-positive groups**. That is the reason items 9 and 10 read as `+4 / −6` in the table above: the headline count drops, and detection quality strictly improves. Do not read the −6 as a regression.
 
-Both fixes are guarded going forward — item 9 by MUST_MERGE cases, item 10 by MUST_NOT_MERGE cases including `1991`/`1983` and `80186`/`80286`.
+**Item 10, refined — and why one library was not enough.** Requiring the keyword also stopped bare trailing years being stripped at all. Maeldun's export contained no case where that mattered, so it looked free. Validating against a second library (the maintainer's own, 160,742 scrobbles) turned up the one it broke: `Comfortably Numb`(4) and `Comfortably Numb 2022`(2) stopped grouping. The final rule strips a bare trailing year only when **all three** hold, each guarding a specific failure:
+
+| Condition | Guards against |
+|---|---|
+| whitespace-separated | `19-2000`, `555-5555` — digits belonging to the title |
+| stem contains a letter | `1991`, `80186` — wholly numeric titles |
+| stem ends alphanumeric | `Spring 1 - 2012` → `spring 1 -`, item 9's dangling separator returning |
+
+Measured after refinement: scoblitz 1200 → 1201, Maeldun unchanged at 559. The six false-positive groups stay removed — every one is a set of genuinely distinct numerically-titled tracks (Crystal Castles `1991`/`1983`, HEALTH `0001`–`0004`, MASTER BOOT RECORD `80186`–`80686`).
+
+The lesson is worth keeping: **a normalizer change validated against a single export is undertested.** One library's blind spot is another's common case. Both exports are now the standing validation set.
+
+Both fixes are guarded going forward — item 9 by MUST_MERGE cases, item 10 by MUST_NOT_MERGE cases including `1991`/`1983` and `80186`/`80286`, plus a `KEY_MUST_NOT_BE` entry for the `Spring 1 - 2012` dangle.
 
 ### 4.2 v0.7.0 — pattern-detector release (scoped, not built)
 

--- a/index.html
+++ b/index.html
@@ -1659,7 +1659,12 @@
             norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove common suffixes
-            norm = norm.replace(/\s*[\(\[].*?(remaster|live|remix|edit|version|mix|demo|acoustic|mono|stereo|single|radio|extended|instrumental|reprise|take \d+|alternate|alt\.|bonus).*?[\)\]]/gi, '');
+            // The \b around feat/ft are load-bearing: without them "ft" matches
+            // inside ordinary words and strips real titles - "Quattro (World
+            // Drifts In)", "Debase (Soft Palate)", "Winter (What We Never Were
+            // After All)" all lose their parenthetical. "feat(uring)?" is one
+            // token so "(Featuring Beth Ditto)" is caught too.
+            norm = norm.replace(/\s*[\(\[].*?(remaster|live|remix|edit|version|mix|demo|acoustic|mono|stereo|single|radio|extended|instrumental|reprise|take \d+|alternate|alt\.|bonus|\bfeat(?:uring)?\b|\bft\b).*?[\)\]]/gi, '');
             // A year may sit between the dash and the keyword ("Midtown - 2023
             // Remaster" - the common Spotify shape). Without the optional year
             // group the rule below strips "2023 Remaster" and orphans the dash,

--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,8 @@
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove remaster/deluxe/edition suffixes
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
-            norm = norm.replace(/\s*-\s*(remaster|deluxe|expanded).*$/i, '');
+            // Optional year, as in normalizeTrack ("Aja - 1999 Remaster")
+            norm = norm.replace(/\s*-\s*(\d{4}\s+)?(remaster|deluxe|expanded).*$/i, '');
             norm = norm.replace(/\s+/g, ' ').trim();
             return norm;
         }
@@ -1659,8 +1660,16 @@
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove common suffixes
             norm = norm.replace(/\s*[\(\[].*?(remaster|live|remix|edit|version|mix|demo|acoustic|mono|stereo|single|radio|extended|instrumental|reprise|take \d+|alternate|alt\.|bonus).*?[\)\]]/gi, '');
-            norm = norm.replace(/\s*-\s*(remaster|live|remix|edit|version|demo|acoustic|mono|stereo|single|radio|extended).*$/i, '');
-            norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)?$/i, ''); // Year suffixes
+            // A year may sit between the dash and the keyword ("Midtown - 2023
+            // Remaster" - the common Spotify shape). Without the optional year
+            // group the rule below strips "2023 Remaster" and orphans the dash,
+            // leaving "midtown -" which groups with nothing.
+            norm = norm.replace(/\s*-\s*(\d{4}\s+)?(remaster|live|remix|edit|version|demo|acoustic|mono|stereo|single|radio|extended).*$/i, '');
+            // Year suffixes. The keyword is REQUIRED: a bare trailing number is
+            // part of the title, not a suffix. Without it this ate real titles
+            // ("1991" and "1983" both became "" and wrongly merged; "19-2000"
+            // became "19-").
+            norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)$/i, '');
             norm = norm.replace(/\s+/g, ' ').trim();
             return norm;
         }

--- a/index.html
+++ b/index.html
@@ -1813,6 +1813,17 @@
             // is the normalizer the 3.15.20 guard is aimed at.
             norm = norm.replace(/[.,]/g, ' ');
             norm = norm.replace(/\s+/g, ' ').trim();
+            // A bare trailing year IS a suffix when it trails a real title
+            // ("Comfortably Numb 2022"), and is NOT one when it is the title, or
+            // part of it ("1991", "19-2000", "555-5555"). Three conditions keep
+            // those apart, and all three are load-bearing:
+            //   - whitespace-separated, so "19-2000" is untouched
+            //   - the stem contains a letter, so "1991" and "80186" are untouched
+            //   - the stem ends alphanumeric, so "Spring 1 - 2012" does not become
+            //     "spring 1 -" and reintroduce the dangling separator
+            // Runs last because it needs the collapsed, trimmed form.
+            norm = norm.replace(/^(.*\S.*?)\s+\d{4}$/, (match, stem) =>
+                (/[a-z]/i.test(stem) && /[a-z0-9)\]]$/i.test(stem)) ? stem : match);
             return norm;
         }
 

--- a/index.html
+++ b/index.html
@@ -904,7 +904,13 @@
                         or click to browse
                     </div>
                 </div>
-                <input type="file" id="file-input" accept=".csv">
+                <!-- Android's picker filters on MIME type, and providers report
+                     CSV inconsistently (text/csv, text/plain, application/vnd.ms-excel).
+                     A bare ".csv" leaves every file greyed out on some devices
+                     (issue #5). Listing the types alongside the extension keeps
+                     desktop behaviour and unblocks those pickers. A wrong file
+                     still fails the format check after it is read. -->
+                <input type="file" id="file-input" accept=".csv,text/csv,text/comma-separated-values,application/csv,application/vnd.ms-excel,text/plain">
             </div>
 
             <div class="sidebar-section" id="nav-section" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -1631,6 +1631,11 @@
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             if (norm.startsWith('the ')) norm = norm.slice(4);
             norm = norm.replace(/\s*&\s*/g, ' and ');
+            // Punctuation maps to a SPACE, never to nothing. Deleting it would
+            // collapse "3.15.20" to "31520" (DESIGN.md 1.7) and join words that
+            // were only ever adjacent across a comma. Runs after the rules
+            // above so keyword tokens like "alt." are still intact for them.
+            norm = norm.replace(/[.,]/g, ' ');
             norm = norm.replace(/\s+/g, ' ').trim();
             return norm;
         }
@@ -1647,6 +1652,8 @@
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
             // Optional year, as in normalizeTrack ("Aja - 1999 Remaster")
             norm = norm.replace(/\s*-\s*(\d{4}\s+)?(remaster|deluxe|expanded).*$/i, '');
+            // Punctuation to a space, never deleted - see normalizeArtist.
+            norm = norm.replace(/[.,]/g, ' ');
             norm = norm.replace(/\s+/g, ' ').trim();
             return norm;
         }
@@ -1675,6 +1682,9 @@
             // ("1991" and "1983" both became "" and wrongly merged; "19-2000"
             // became "19-").
             norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)$/i, '');
+            // Punctuation to a space, never deleted - see normalizeArtist. This
+            // is the normalizer the 3.15.20 guard is aimed at.
+            norm = norm.replace(/[.,]/g, ' ');
             norm = norm.replace(/\s+/g, ' ').trim();
             return norm;
         }

--- a/index.html
+++ b/index.html
@@ -1608,6 +1608,63 @@
             return new Set(names.map(getVisibleString)).size === 1;
         }
 
+        // --- Normalization keys ----------------------------------------------
+        // These three reduce a raw name to the key its variation group is
+        // clustered under. They are the highest-risk code in the file: a change
+        // here silently changes what groups with what.
+        //
+        // They are top-level (rather than inline in the finders) so that
+        // tests/merge-contract.js can extract and exercise them directly. Keep
+        // them top-level, keep them pure, and add cases to the merge contract
+        // BEFORE changing behaviour here.
+        //
+        // The three are deliberately NOT interchangeable - see docs/DESIGN.md
+        // section 1.7 for the per-normalizer table of which rules apply where.
+
+        // Artist: strips a leading "the" and unifies &/and. Does NOT strip
+        // keyword suffixes - "(Remastered)" is meaningless on an artist.
+        function normalizeArtist(artist) {
+            if (!artist) return '';
+            let norm = artist.toLowerCase().trim();
+            norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
+            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            if (norm.startsWith('the ')) norm = norm.slice(4);
+            norm = norm.replace(/\s*&\s*/g, ' and ');
+            norm = norm.replace(/\s+/g, ' ').trim();
+            return norm;
+        }
+
+        // Album: strips edition/remaster suffixes. Does NOT strip a leading
+        // "the" - "The Wall" and "Wall" are different albums.
+        function normalizeAlbum(album) {
+            if (!album) return '';
+            let norm = album.toLowerCase();
+            norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
+            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            // Remove remaster/deluxe/edition suffixes
+            norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
+            norm = norm.replace(/\s*-\s*(remaster|deluxe|expanded).*$/i, '');
+            norm = norm.replace(/\s+/g, ' ').trim();
+            return norm;
+        }
+
+        // Track: as album, plus live/remix/edit/take and bare year suffixes.
+        function normalizeTrack(track) {
+            if (!track) return '';
+            let norm = track.toLowerCase();
+            norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
+            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            // Remove common suffixes
+            norm = norm.replace(/\s*[\(\[].*?(remaster|live|remix|edit|version|mix|demo|acoustic|mono|stereo|single|radio|extended|instrumental|reprise|take \d+|alternate|alt\.|bonus).*?[\)\]]/gi, '');
+            norm = norm.replace(/\s*-\s*(remaster|live|remix|edit|version|demo|acoustic|mono|stereo|single|radio|extended).*$/i, '');
+            norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)?$/i, ''); // Year suffixes
+            norm = norm.replace(/\s+/g, ' ').trim();
+            return norm;
+        }
+
         // Find artist variations (like "The Beatles" vs "Beatles")
         function findArtistVariations(scrobbles) {
             console.log('Finding artist variations...');
@@ -1623,14 +1680,8 @@
 
             const normalized = new Map();
             Object.keys(artistCounts).forEach(artist => {
-                let norm = artist.toLowerCase().trim();
-                norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-                norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
-                norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
-                if (norm.startsWith('the ')) norm = norm.slice(4);
-                norm = norm.replace(/\s*&\s*/g, ' and ');
-                norm = norm.replace(/\s+/g, ' ').trim();
-                
+                const norm = normalizeArtist(artist);
+
                 if (!normalized.has(norm)) normalized.set(norm, []);
                 normalized.get(norm).push({ name: artist, count: artistCounts[artist], hasSmartQuotes: /[\u2018\u2019\u201C\u201D]/.test(artist), hasInvisible: hasInvisibleChars(artist) });
             });
@@ -1676,19 +1727,6 @@
             });
             
             console.log('Unique artist+album combos:', Object.keys(albumCounts).length);
-
-            function normalizeAlbum(album) {
-                if (!album) return '';
-                let norm = album.toLowerCase();
-                norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-                norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
-                norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
-                // Remove remaster/deluxe/edition suffixes
-                norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
-                norm = norm.replace(/\s*-\s*(remaster|deluxe|expanded).*$/i, '');
-                norm = norm.replace(/\s+/g, ' ').trim();
-                return norm;
-            }
 
             const grouped = new Map();
             Object.keys(albumCounts).forEach(key => {
@@ -1876,20 +1914,6 @@
             });
             
             console.log('Unique artist+track combos:', Object.keys(trackCounts).length);
-
-            function normalizeTrack(track) {
-                if (!track) return '';
-                let norm = track.toLowerCase();
-                norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-                norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
-                norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
-                // Remove common suffixes
-                norm = norm.replace(/\s*[\(\[].*?(remaster|live|remix|edit|version|mix|demo|acoustic|mono|stereo|single|radio|extended|instrumental|reprise|take \d+|alternate|alt\.|bonus).*?[\)\]]/gi, '');
-                norm = norm.replace(/\s*-\s*(remaster|live|remix|edit|version|demo|acoustic|mono|stereo|single|radio|extended).*$/i, '');
-                norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)?$/i, ''); // Year suffixes
-                norm = norm.replace(/\s+/g, ' ').trim();
-                return norm;
-            }
 
             const grouped = new Map();
             Object.keys(trackCounts).forEach(key => {

--- a/index.html
+++ b/index.html
@@ -1652,6 +1652,9 @@
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
             // Optional year, as in normalizeTrack ("Aja - 1999 Remaster")
             norm = norm.replace(/\s*-\s*(\d{4}\s+)?(remaster|deluxe|expanded).*$/i, '');
+            // Same &/and unification the artist normalizer has always had. Its
+            // absence here (and on tracks) is why discussion #10 went unflagged.
+            norm = norm.replace(/\s*&\s*/g, ' and ');
             // Punctuation to a space, never deleted - see normalizeArtist.
             norm = norm.replace(/[.,]/g, ' ');
             norm = norm.replace(/\s+/g, ' ').trim();
@@ -1682,6 +1685,10 @@
             // ("1991" and "1983" both became "" and wrongly merged; "19-2000"
             // became "19-").
             norm = norm.replace(/\s*\d{4}\s*(remaster|remix|version)$/i, '');
+            // Same &/and unification the artist normalizer has always had. Its
+            // absence here is the whole of discussion #10: "9th & Hennepin" and
+            // "9th and Hennepin" both existed and never grouped.
+            norm = norm.replace(/\s*&\s*/g, ' and ');
             // Punctuation to a space, never deleted - see normalizeArtist. This
             // is the normalizer the 3.15.20 guard is aimed at.
             norm = norm.replace(/[.,]/g, ' ');

--- a/index.html
+++ b/index.html
@@ -339,6 +339,14 @@
             letter-spacing: 0.03em;
             cursor: help;
         }
+        /* Diacritic chips say "here is what differs", not "this is wrong" - the
+           red reveal chip would read as an accusation against a spelling that is
+           very often the correct one. Blue keeps it informational. */
+        .char-chip.diacritic {
+            background: rgba(74, 158, 255, 0.2);
+            color: var(--accent-blue);
+            font-weight: 500;
+        }
 
         .filter-btn {
             padding: 0.75rem 1.25rem;
@@ -1614,6 +1622,53 @@
             return new Set(names.map(getVisibleString)).size === 1;
         }
 
+        // --- Confusable diacritics -------------------------------------------
+        // Folding diacritics (see the normalizers) groups names the user may not
+        // be able to tell apart: "Subcarpati" spelled with comma-below vs cedilla
+        // is the same picture at body-text size. Those rows need a chip saying
+        // what differs. "Motorhead" with and without the umlaut does not - the
+        // eye already does that work, and the umlaut is the band's actual name,
+        // so flagging it would imply the ASCII form is the fixed one. The
+        // criterion is perceptual, not by character class - docs/DESIGN.md 1.9.
+
+        // Split a string into one entry per base character, carrying whatever
+        // combining marks follow it.
+        function baseProfile(str) {
+            const out = [];
+            for (const ch of String(str || '').normalize('NFD')) {
+                if (/[\u0300-\u036f]/.test(ch)) {
+                    if (out.length) out[out.length - 1].marks += ch;
+                } else {
+                    out.push({ base: ch, marks: '' });
+                }
+            }
+            return out;
+        }
+
+        // For each name in a variation group, which of its characters differ from
+        // a sibling by carrying a DIFFERENT mark rather than by having one at all.
+        // Returns an array of arrays of composed characters, parallel to `names`.
+        // Only compares members whose base letters line up; anything differing in
+        // more than its marks is visibly different already.
+        function confusableMarkChars(names) {
+            const profiles = names.map(baseProfile);
+            const found = names.map(() => new Set());
+            for (let i = 0; i < names.length; i++) {
+                for (let j = i + 1; j < names.length; j++) {
+                    const a = profiles[i], b = profiles[j];
+                    if (a.length !== b.length) continue;
+                    for (let k = 0; k < a.length; k++) {
+                        if (a[k].base !== b[k].base) continue;    // different letter: visible
+                        if (!a[k].marks || !b[k].marks) continue; // one is bare: visible
+                        if (a[k].marks === b[k].marks) continue;  // identical: nothing to say
+                        found[i].add((a[k].base + a[k].marks).normalize('NFC'));
+                        found[j].add((b[k].base + b[k].marks).normalize('NFC'));
+                    }
+                }
+            }
+            return found.map(set => [...set]);
+        }
+
         // --- Normalization keys ----------------------------------------------
         // These three reduce a raw name to the key its variation group is
         // clustered under. They are the highest-risk code in the file: a change
@@ -1639,6 +1694,17 @@
             // so Last.fm split them onto separate pages (issue #12).
             norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            // Fold diacritics for GROUPING only - the original spelling is
+            // what gets displayed, and the user still picks the winner.
+            // NFD splits a letter into base + combining mark, then the marks
+            // are dropped. This is what lets Motorhead meet Motorhead, and
+            // more importantly what reconciles Romanian comma-below with
+            // cedilla (U+0219 vs U+015F), which look identical on screen.
+            // NFD is canonical-only on purpose: NFKD would also rewrite
+            // ligatures and superscripts, which is a different decision.
+            // Known limit - letters with a stroke rather than a mark do not
+            // decompose, so o-slash, l-stroke and d-stroke are left alone.
+            norm = norm.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             if (norm.startsWith('the ')) norm = norm.slice(4);
             norm = norm.replace(/\s*&\s*/g, ' and ');
             // Punctuation maps to a SPACE, never to nothing. Deleting it would
@@ -1669,6 +1735,17 @@
             // so running before them changes nothing for them.
             norm = norm.replace(/\[/g, '(').replace(/\]/g, ')');
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            // Fold diacritics for GROUPING only - the original spelling is
+            // what gets displayed, and the user still picks the winner.
+            // NFD splits a letter into base + combining mark, then the marks
+            // are dropped. This is what lets Motorhead meet Motorhead, and
+            // more importantly what reconciles Romanian comma-below with
+            // cedilla (U+0219 vs U+015F), which look identical on screen.
+            // NFD is canonical-only on purpose: NFKD would also rewrite
+            // ligatures and superscripts, which is a different decision.
+            // Known limit - letters with a stroke rather than a mark do not
+            // decompose, so o-slash, l-stroke and d-stroke are left alone.
+            norm = norm.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             // Remove remaster/deluxe/edition suffixes
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
             // Optional year, as in normalizeTrack ("Aja - 1999 Remaster")
@@ -1700,6 +1777,17 @@
             // so running before them changes nothing for them.
             norm = norm.replace(/\[/g, '(').replace(/\]/g, ')');
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
+            // Fold diacritics for GROUPING only - the original spelling is
+            // what gets displayed, and the user still picks the winner.
+            // NFD splits a letter into base + combining mark, then the marks
+            // are dropped. This is what lets Motorhead meet Motorhead, and
+            // more importantly what reconciles Romanian comma-below with
+            // cedilla (U+0219 vs U+015F), which look identical on screen.
+            // NFD is canonical-only on purpose: NFKD would also rewrite
+            // ligatures and superscripts, which is a different decision.
+            // Known limit - letters with a stroke rather than a mark do not
+            // decompose, so o-slash, l-stroke and d-stroke are left alone.
+            norm = norm.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             // Remove common suffixes
             // The \b around feat/ft are load-bearing: without them "ft" matches
             // inside ordinary words and strips real titles - "Quattro (World
@@ -2509,6 +2597,10 @@
                     }
                 }
                 
+                // Which rows differ from a sibling only by which diacritic
+                // they carry - the ones the eye cannot separate (1.9).
+                const confusableByRow = confusableMarkChars(variationsToRender.map(v => v.name || ''));
+
                 const variationsHtml = variationsToRender.map((v, i) => {
                     // Determine the Last.fm URL based on issue type
                     let lastFmUrl = '';
@@ -2537,6 +2629,14 @@
                     const smartQuoteWarning = v.hasSmartQuotes 
                         ? '<span class="smart-quote-warning">⚠️ smart quote</span>' 
                         : '';
+
+                    // Informational, not a warning: this row is here because its
+                    // diacritic differs from a sibling's in a way you cannot see.
+                    // No warning glyph - see 1.9.
+                    const confusableHtml = (confusableByRow[i] || []).map(ch => {
+                        const hex = 'U+' + ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0');
+                        return `<span class="char-chip diacritic" title="${escapeHtml(ch + ' ' + hex)}">${escapeHtml(ch)} ${hex}</span>`;
+                    }).join('');
                     
                     // Per-item lookup button for missing albums and compilations
                     let itemLookupHtml = '';
@@ -2569,7 +2669,7 @@
                     
                     return `
                         <div class="variation-item">
-                            <span class="variation-value">${nameHtml}${invisibleWarning}${smartQuoteWarning}</span>
+                            <span class="variation-value">${nameHtml}${confusableHtml}${invisibleWarning}${smartQuoteWarning}</span>
                             ${v.count ? `<span class="variation-count">${v.count}</span>` : ''}
                             ${lastFmLinkHtml}
                             ${itemLookupHtml}

--- a/index.html
+++ b/index.html
@@ -882,7 +882,7 @@
             <div class="logo-icon">📊</div>
             <div class="logo-text">
                 <h1>Scrobble Analyzer</h1>
-                <div class="tagline">Find & Fix Your Last.fm Data <span style="color: var(--accent-orange); margin-left: 0.5rem;">v0.6.0</span></div>
+                <div class="tagline">Find & Fix Your Last.fm Data <span style="color: var(--accent-orange); margin-left: 0.5rem;">v0.6.1</span></div>
             </div>
         </div>
         <div class="header-stats" id="header-stats" style="display: none;">
@@ -993,14 +993,21 @@
                         <li>Drag the file to the upload box in the sidebar, or click the box to browse</li>
                     </ol>
                     
-                    <h3 style="font-size: 1rem; color: var(--accent-orange); margin-bottom: 1rem;">🆕 What's New in v0.6.0</h3>
+                    <h3 style="font-size: 1rem; color: var(--accent-orange); margin-bottom: 1rem;">🆕 What's New in v0.6.1</h3>
+                    <!-- max-width/margin override: .empty-state p centres text in a
+                         400px column, which is right for the intro blurb above but
+                         indents this one oddly inside the card. -->
+                    <p style="color: var(--text-secondary); font-size: 0.9rem; max-width: none; margin: 0 0 0.75rem;">This release is all about the matching itself - the spellings you reported that should have been grouped, and now are. Expect more issues than your last export showed.</p>
                     <ul style="color: var(--text-secondary); font-size: 0.9rem; padding-left: 1.25rem; margin-bottom: 1.5rem;">
-                        <li style="margin-bottom: 0.5rem;"><strong>Dismissals survive new exports</strong> - Now tied to your Last.fm username instead of the uploaded file. Existing dismissals migrate automatically.</li>
-                        <li style="margin-bottom: 0.5rem;"><strong>Character reveal</strong> - Invisible characters and stray spaces now show as labeled chips, so you can see exactly what's different</li>
-                        <li style="margin-bottom: 0.5rem;"><strong>Track-level invisible detection</strong> - Tracks now get the same invisible-character scan as artists and albums</li>
-                        <li style="margin-bottom: 0.5rem;"><strong>One issue, one category</strong> - Variations that differ only by invisible characters now appear only under Invisible Characters</li>
-                        <li style="margin-bottom: 0.5rem;"><strong>Export options</strong> - Choose whether reports include dismissed items</li>
-                        <li style="margin-bottom: 0.5rem;"><strong>Fixes & polish</strong> - Titles with quotes parse correctly, "Gold" compilations are detected again, plus search/filter clear buttons and a calmer look</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Accented spellings</strong> - Motörhead now groups with Motorhead, Déjà Voodoo with Deja Voodoo</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Look-alike accents get a chip</strong> - When two spellings differ only by which accent they use, a small blue chip shows the exact character and its code point, because the names themselves look identical</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Punctuation and spacing</strong> - "Albert Hammond, Jr." now groups with "Albert Hammond Jr", and "T. Rex" with "T.Rex"</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Featured artists</strong> - "(feat. …)" and "[ft. …]" now group with the plain title</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>&amp; and "and"</strong> - Now unified on tracks and albums, not just artist names</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>More apostrophe styles</strong> - Acute accents, backticks and modifier apostrophes join the smart quotes</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Remasters dated in the title</strong> - "Close to Me - 2006 Remaster" now groups with "Close to Me"</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Fewer false alarms</strong> - Numerically titled tracks are no longer lumped together, so 1991 stays separate from 1983</li>
+                        <li style="margin-bottom: 0.5rem;"><strong>Android uploads</strong> - The file picker should now let you select your CSV</li>
                     </ul>
                     
                     <h3 style="font-size: 1rem; color: var(--accent-orange); margin-bottom: 1rem;">💬 Feedback & Support</h3>

--- a/index.html
+++ b/index.html
@@ -339,10 +339,12 @@
             letter-spacing: 0.03em;
             cursor: help;
         }
-        /* Diacritic chips say "here is what differs", not "this is wrong" - the
+        /* Look-alike chips say "here is what differs", not "this is wrong" - the
            red reveal chip would read as an accusation against a spelling that is
-           very often the correct one. Blue keeps it informational. */
-        .char-chip.diacritic {
+           very often the correct one (a curly apostrophe is what Last.fm's own
+           catalog frequently uses). Blue keeps it informational. Shared by the
+           diacritic and quote-character chips, which solve the same problem. */
+        .char-chip.lookalike {
             background: rgba(74, 158, 255, 0.2);
             color: var(--accent-blue);
             font-weight: 500;
@@ -458,17 +460,6 @@
             border-radius: 3px;
             font-size: 0.65rem;
             color: #ec4899;
-            margin-left: 0.5rem;
-        }
-
-        /* Smart quote warning */
-        .smart-quote-warning {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(251, 191, 36, 0.2);
-            border-radius: 3px;
-            font-size: 0.65rem;
-            color: #fbbf24;
             margin-left: 0.5rem;
         }
 
@@ -1676,6 +1667,27 @@
             return found.map(set => [...set]);
         }
 
+        // Quote and apostrophe characters that look like the ASCII ones but are
+        // not, and that the normalizers fold away. Same problem as the diacritics
+        // above - two rows that read identically - so they get the same chip.
+        //
+        // This must stay in step with the apostrophe/quote class in the three
+        // normalizers; tests/merge-contract.js asserts that every character
+        // returned here is actually folded by them.
+        //
+        // Deliberately per-row rather than comparing siblings: a group can pair
+        // "Couldn`t Stand The Weather" with "Couldn't Stand the Weather (Legacy
+        // Edition)", where the strings differ in length and a position-aligned
+        // comparison would find nothing.
+        //
+        // The chip names the character rather than its category. "Smart quote"
+        // was the old label and it went stale the moment the class grew to
+        // include an acute accent and a backtick - showing U+0060 cannot.
+        function lookalikeQuoteChars(str) {
+            const found = String(str || '').match(/[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/g);
+            return found ? [...new Set(found)] : [];
+        }
+
         // --- Normalization keys ----------------------------------------------
         // These three reduce a raw name to the key its variation group is
         // clustered under. They are the highest-risk code in the file: a change
@@ -1852,7 +1864,7 @@
                 const norm = normalizeArtist(artist);
 
                 if (!normalized.has(norm)) normalized.set(norm, []);
-                normalized.get(norm).push({ name: artist, count: artistCounts[artist], hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(artist), hasInvisible: hasInvisibleChars(artist) });
+                normalized.get(norm).push({ name: artist, count: artistCounts[artist], hasInvisible: hasInvisibleChars(artist) });
             });
 
             const issues = [];
@@ -1908,7 +1920,6 @@
                     name: album, 
                     count: albumCounts[key],
                     artist: artist,
-                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(album),
                     hasInvisible: hasInvisibleChars(album)
                 });
             });
@@ -2095,7 +2106,6 @@
                     name: track, 
                     count: trackCounts[key],
                     artist: artist,
-                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(track),
                     hasInvisible: hasInvisibleChars(track)
                 });
             });
@@ -2644,16 +2654,21 @@
                         ? '<span class="invisible-warning">⚠️ invisible chars</span>' 
                         : '';
                     
-                    const smartQuoteWarning = v.hasSmartQuotes 
-                        ? '<span class="smart-quote-warning">⚠️ smart quote</span>' 
-                        : '';
-
-                    // Informational, not a warning: this row is here because its
-                    // diacritic differs from a sibling's in a way you cannot see.
-                    // No warning glyph - see 1.9.
-                    const confusableHtml = (confusableByRow[i] || []).map(ch => {
+                    // Look-alike characters get a chip naming the character
+                    // itself, not its category - informational, no warning
+                    // glyph (1.9). Two sources, one presentation:
+                    //   - a diacritic that differs from a sibling's
+                    //   - a quote/apostrophe that is not the ASCII one
+                    // Naming the character is what keeps this honest. The
+                    // old label read "smart quote", which stopped being true
+                    // as soon as the class grew an acute accent and a
+                    // backtick; "U+0060" cannot go stale that way.
+                    const lookalikeHtml = [
+                        ...(confusableByRow[i] || []),
+                        ...lookalikeQuoteChars(v.name)
+                    ].map(ch => {
                         const hex = 'U+' + ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0');
-                        return `<span class="char-chip diacritic" title="${escapeHtml(ch + ' ' + hex)}">${escapeHtml(ch)} ${hex}</span>`;
+                        return `<span class="char-chip lookalike" title="${escapeHtml(ch + ' ' + hex)}">${escapeHtml(ch)} ${hex}</span>`;
                     }).join('');
                     
                     // Per-item lookup button for missing albums and compilations
@@ -2687,7 +2702,7 @@
                     
                     return `
                         <div class="variation-item">
-                            <span class="variation-value">${nameHtml}${confusableHtml}${invisibleWarning}${smartQuoteWarning}</span>
+                            <span class="variation-value">${nameHtml}${lookalikeHtml}${invisibleWarning}</span>
                             ${v.count ? `<span class="variation-count">${v.count}</span>` : ''}
                             ${lastFmLinkHtml}
                             ${itemLookupHtml}

--- a/index.html
+++ b/index.html
@@ -1627,7 +1627,11 @@
             if (!artist) return '';
             let norm = artist.toLowerCase().trim();
             norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            // Apostrophe-like characters → ASCII. Beyond the smart quotes this
+            // covers U+00B4 acute, U+0060 backtick and U+02BC modifier-letter
+            // apostrophe. File-sharing-era tags used all three as apostrophes,
+            // so Last.fm split them onto separate pages (issue #12).
+            norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             if (norm.startsWith('the ')) norm = norm.slice(4);
             norm = norm.replace(/\s*&\s*/g, ' and ');
@@ -1646,7 +1650,11 @@
             if (!album) return '';
             let norm = album.toLowerCase();
             norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            // Apostrophe-like characters → ASCII. Beyond the smart quotes this
+            // covers U+00B4 acute, U+0060 backtick and U+02BC modifier-letter
+            // apostrophe. File-sharing-era tags used all three as apostrophes,
+            // so Last.fm split them onto separate pages (issue #12).
+            norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove remaster/deluxe/edition suffixes
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
@@ -1666,7 +1674,11 @@
             if (!track) return '';
             let norm = track.toLowerCase();
             norm = norm.replace(/\u00a0/g, ' ');  // Replace non-breaking spaces
-            norm = norm.replace(/[\u2018\u2019]/g, "'");  // Smart single quotes → ASCII
+            // Apostrophe-like characters → ASCII. Beyond the smart quotes this
+            // covers U+00B4 acute, U+0060 backtick and U+02BC modifier-letter
+            // apostrophe. File-sharing-era tags used all three as apostrophes,
+            // so Last.fm split them onto separate pages (issue #12).
+            norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove common suffixes
             // The \b around feat/ft are load-bearing: without them "ft" matches
@@ -1714,7 +1726,7 @@
                 const norm = normalizeArtist(artist);
 
                 if (!normalized.has(norm)) normalized.set(norm, []);
-                normalized.get(norm).push({ name: artist, count: artistCounts[artist], hasSmartQuotes: /[\u2018\u2019\u201C\u201D]/.test(artist), hasInvisible: hasInvisibleChars(artist) });
+                normalized.get(norm).push({ name: artist, count: artistCounts[artist], hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(artist), hasInvisible: hasInvisibleChars(artist) });
             });
 
             const issues = [];
@@ -1770,7 +1782,7 @@
                     name: album, 
                     count: albumCounts[key],
                     artist: artist,
-                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D]/.test(album),
+                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(album),
                     hasInvisible: hasInvisibleChars(album)
                 });
             });
@@ -1957,7 +1969,7 @@
                     name: track, 
                     count: trackCounts[key],
                     artist: artist,
-                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D]/.test(track),
+                    hasSmartQuotes: /[\u2018\u2019\u201C\u201D\u00B4\u0060\u02BC]/.test(track),
                     hasInvisible: hasInvisibleChars(track)
                 });
             });

--- a/index.html
+++ b/index.html
@@ -1655,6 +1655,13 @@
             // apostrophe. File-sharing-era tags used all three as apostrophes,
             // so Last.fm split them onto separate pages (issue #12).
             norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
+            // Square brackets and parentheses are interchangeable in the wild
+            // ("Ramalama [Bang Bang]" vs "Ramalama (Bang Bang)"). Canonicalise
+            // to parentheses so the container type stops mattering. Safe by
+            // construction: this can only merge strings that already differed
+            // nowhere else. The suffix rules below accept either form anyway,
+            // so running before them changes nothing for them.
+            norm = norm.replace(/\[/g, '(').replace(/\]/g, ')');
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove remaster/deluxe/edition suffixes
             norm = norm.replace(/\s*[\(\[].*?(remaster|deluxe|edition|bonus|expanded|anniversary|version|disc \d).*?[\)\]]/gi, '');
@@ -1679,6 +1686,13 @@
             // apostrophe. File-sharing-era tags used all three as apostrophes,
             // so Last.fm split them onto separate pages (issue #12).
             norm = norm.replace(/[\u2018\u2019\u00B4\u0060\u02BC]/g, "'");
+            // Square brackets and parentheses are interchangeable in the wild
+            // ("Ramalama [Bang Bang]" vs "Ramalama (Bang Bang)"). Canonicalise
+            // to parentheses so the container type stops mattering. Safe by
+            // construction: this can only merge strings that already differed
+            // nowhere else. The suffix rules below accept either form anyway,
+            // so running before them changes nothing for them.
+            norm = norm.replace(/\[/g, '(').replace(/\]/g, ')');
             norm = norm.replace(/[\u201C\u201D]/g, '"');  // Smart double quotes → ASCII
             // Remove common suffixes
             // The \b around feat/ft are load-bearing: without them "ft" matches

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -46,7 +46,7 @@ const HTML = path.join(__dirname, '..', 'index.html');
 function loadNormalizers() {
     const html = fs.readFileSync(HTML, 'utf8');
     const names = ['normalizeArtist', 'normalizeAlbum', 'normalizeTrack',
-                   'baseProfile', 'confusableMarkChars'];
+                   'baseProfile', 'confusableMarkChars', 'lookalikeQuoteChars'];
     const sources = names.map(name => {
         const open = `        function ${name}(`;
         const start = html.indexOf(open);
@@ -67,7 +67,8 @@ function loadNormalizers() {
     return factory();
 }
 
-const { normalizeArtist, normalizeAlbum, normalizeTrack, confusableMarkChars } = loadNormalizers();
+const { normalizeArtist, normalizeAlbum, normalizeTrack,
+        confusableMarkChars, lookalikeQuoteChars } = loadNormalizers();
 
 const FN = { artist: normalizeArtist, album: normalizeAlbum, track: normalizeTrack };
 
@@ -255,6 +256,34 @@ KEY_MUST_NOT_BE.forEach(([field, input, forbidden, why]) => {
     else passed++;
 });
 
+// Drift guard: the quote chip and the normalizers each carry their own copy of
+// the apostrophe/quote character class. If they fall out of step the UI either
+// chips a character that does not affect grouping, or stays silent about one
+// that does. Every character the chip is willing to show must be folded to its
+// ASCII equivalent by all three normalizers.
+// The probe must DISCOVER the class, never restate it. An earlier version of
+// this guard passed a hand-written copy of the characters, so widening the chip
+// class past that copy was invisible to it - the test drifted alongside the code
+// it was meant to pin. Sweeping a wide range instead means whatever the chip is
+// willing to match gets found and checked.
+const PROBE = (() => {
+    let s = '';
+    for (let cp = 0x20; cp <= 0x30FF; cp++) {
+        if (cp >= 0xD800 && cp <= 0xDFFF) continue;   // surrogates
+        s += String.fromCodePoint(cp);
+    }
+    return s;
+})();
+const driftFailures = [];
+lookalikeQuoteChars(PROBE).forEach(ch => {
+    const hex = 'U+' + ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0');
+    ['artist', 'album', 'track'].forEach(field => {
+        const got = FN[field]('x' + ch + 'y');
+        if (got === "x'y" || got === 'x"y') passed++;
+        else driftFailures.push({ ch, hex, field, got });
+    });
+});
+
 const chipFailures = [];
 CHIP_EXPECT.forEach(([names, expected, why]) => {
     const got = confusableMarkChars(names).map(chips => chips.length > 0);
@@ -271,7 +300,7 @@ KNOWN_MISS.forEach(([f, a, b, shouldMatch, why]) => {
 
 console.log('\nmerge contract  ' + DIM + '(normalizers read live from index.html)' + OFF + '\n');
 
-const totalFailures = failures.length + keyFailures.length + chipFailures.length;
+const totalFailures = failures.length + keyFailures.length + chipFailures.length + driftFailures.length;
 
 if (totalFailures === 0) {
     console.log(`  ${GREEN}PASS${OFF}  ${passed} assertions`);
@@ -288,6 +317,11 @@ if (totalFailures === 0) {
         console.log(`  ${RED}x${OFF} [${f.field}] key guard violated`);
         console.log(`      ${JSON.stringify(f.input)}  ->  ${JSON.stringify(f.got)}  ${RED}(forbidden)${OFF}`);
         console.log(`      ${DIM}${f.why}${OFF}\n`);
+    });
+    driftFailures.forEach(f => {
+        console.log(`  ${RED}x${OFF} [drift] the chip shows ${f.ch} ${f.hex}, but normalize${f.field[0].toUpperCase()}${f.field.slice(1)} does not fold it`);
+        console.log(`      ${JSON.stringify('x' + f.ch + 'y')}  ->  ${JSON.stringify(f.got)}`);
+        console.log(`      ${DIM}chip class and normalizer class have drifted apart${OFF}\n`);
     });
     chipFailures.forEach(f => {
         console.log(`  ${RED}x${OFF} [chip] wrong rows chipped`);

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -113,6 +113,12 @@ const MUST_MERGE = [
     ['track',  'Skin & Bones',   'Skin And Bones',   'same, mixed case'],
     ['album',  'Young & Old',    'Young and Old',    'the rule reaches albums too'],
     ['album',  'X&Y',            'X & Y',            'no spaces around the ampersand'],
+
+    // --- v0.6.1 item 6: apostrophe-like characters (issue #12) ---
+    ['track',  'Someone´s in the Wolf',  "Someone's in the Wolf",  'U+00B4 acute, the reported case'],
+    ['track',  'She Don`t Use Jelly',    "She Don't Use Jelly",    'U+0060 backtick'],
+    ['track',  'Love Ainʼt No Stranger', "Love Ain't No Stranger", 'U+02BC modifier-letter apostrophe'],
+    ['track',  'Goin’ Out West',         "Goin' Out West",         'U+2019, unchanged by this item'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -169,8 +175,6 @@ const KNOWN_MISS = [
         'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
     ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', true,
         'issue #17 - bracket/paren containers not canonicalised yet (v0.6.1 item 7)'],
-    ['track',  'Someone´s in the Wolf', "Someone's in the Wolf", true,
-        'issue #12 - U+00B4 not in the apostrophe class yet (v0.6.1 item 6)'],
 
     // --- no viable detector, not scoped to any release (DESIGN.md 3.7) ---
     ['track',  'Cartoons and Macramé Wounds', 'Cartoons and Macreme Wounds', true,

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -132,6 +132,11 @@ const MUST_MERGE = [
     ['artist', 'Ștefan Hrușcă', 'Stefan Hrusca', 'three-way split in the wild, 61/16/15 plays'],
     ['track',  'Naïve',         'Naive',         'diaeresis'],
     ['album',  'Oxygène',       'Oxygene',       'grave accent, album normalizer'],
+
+    // --- item 10, refined: a bare year IS a suffix when it trails a real title ---
+    ['track',  'Comfortably Numb 2022', 'Comfortably Numb',
+        'found only in a second library - the first strict rule lost this'],
+    ['track',  'Blue Monday 1988',      'Blue Monday', 'same shape'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -175,6 +180,9 @@ const KEY_MUST_NOT_BE = [
         'DESIGN.md 1.7 title guard: punctuation must map to a SPACE, never be ' +
         'deleted. If this fires, a rule is deleting "." instead of replacing it.'],
     ['album', '3.15.20', '31520', 'same guard on the album normalizer'],
+    ['track', 'Spring 1 - 2012', 'spring 1 -',
+        'the bare-year rule must not strip a year that leaves a dangling ' +
+        'separator behind - that is the item 9 bug coming back in through item 10.'],
 ];
 
 // Which rows get a confusable-diacritic chip (DESIGN.md 1.9 / 4.1.2).

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -107,6 +107,12 @@ const MUST_MERGE = [
     ['track',  'You, Appearing',      'You Appearing',      'comma to a space, not to nothing'],
     ['album',  'Endtroducing.....',   'Endtroducing',       'ellipsis run'],
     ['album',  'Attack, Decay, Sustain, Release', 'Attack Decay Sustain Release', 'serial commas'],
+
+    // --- v0.6.1 item 5: &/and on tracks and albums, as artists always had ---
+    ['track',  '9th & Hennepin', '9th and Hennepin', 'discussion #10, the reported case'],
+    ['track',  'Skin & Bones',   'Skin And Bones',   'same, mixed case'],
+    ['album',  'Young & Old',    'Young and Old',    'the rule reaches albums too'],
+    ['album',  'X&Y',            'X & Y',            'no spaces around the ampersand'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -161,8 +167,6 @@ const KNOWN_MISS = [
     // --- scoped for v0.6.1, expected to flip as items land ---
     ['artist', 'Motörhead', 'Motorhead', true,
         'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
-    ['track',  '9th & Hennepin', '9th and Hennepin', true,
-        'discussion #10 - no ampersand rule on tracks yet (v0.6.1 item 5)'],
     ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', true,
         'issue #17 - bracket/paren containers not canonicalised yet (v0.6.1 item 7)'],
     ['track',  'Someone´s in the Wolf', "Someone's in the Wolf", true,

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -45,7 +45,8 @@ const HTML = path.join(__dirname, '..', 'index.html');
 // --- load the real normalizers straight out of index.html --------------------
 function loadNormalizers() {
     const html = fs.readFileSync(HTML, 'utf8');
-    const names = ['normalizeArtist', 'normalizeAlbum', 'normalizeTrack'];
+    const names = ['normalizeArtist', 'normalizeAlbum', 'normalizeTrack',
+                   'baseProfile', 'confusableMarkChars'];
     const sources = names.map(name => {
         const open = `        function ${name}(`;
         const start = html.indexOf(open);
@@ -66,7 +67,7 @@ function loadNormalizers() {
     return factory();
 }
 
-const { normalizeArtist, normalizeAlbum, normalizeTrack } = loadNormalizers();
+const { normalizeArtist, normalizeAlbum, normalizeTrack, confusableMarkChars } = loadNormalizers();
 
 const FN = { artist: normalizeArtist, album: normalizeAlbum, track: normalizeTrack };
 
@@ -124,6 +125,13 @@ const MUST_MERGE = [
     ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', 'issue #17, the general class'],
     ['track',  'Track [Interlude]',    'Track (Interlude)',    'no keyword inside, so only the container differs (DESIGN.md 3.6)'],
     ['album',  'Noise [Reprise]',      'Noise (Reprise)',       'the rule reaches albums too'],
+
+    // --- v0.6.1 item 4: diacritic folding ---
+    ['artist', 'Motörhead',     'Motorhead',     'issue #14, the reported case'],
+    ['artist', 'Subcarpați',    'Subcarpaţi',    'comma-below vs cedilla, U+021B vs U+0163'],
+    ['artist', 'Ștefan Hrușcă', 'Stefan Hrusca', 'three-way split in the wild, 61/16/15 plays'],
+    ['track',  'Naïve',         'Naive',         'diaeresis'],
+    ['album',  'Oxygène',       'Oxygene',       'grave accent, album normalizer'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -169,6 +177,31 @@ const KEY_MUST_NOT_BE = [
     ['album', '3.15.20', '31520', 'same guard on the album normalizer'],
 ];
 
+// Which rows get a confusable-diacritic chip (DESIGN.md 1.9 / 4.1.2).
+//
+// Folding diacritics groups names the eye may not be able to separate. The chip
+// says what differs - but only where the difference is genuinely invisible. The
+// test is perceptual, not by character class: mark-vs-different-mark gets a
+// chip, mark-vs-bare-letter does not, because you can already see that one.
+//
+// [names in the group, expected chip? per name, why]
+const CHIP_EXPECT = [
+    [['Subcarpați', 'Subcarpaţi'], [true, true],
+        'comma-below vs cedilla - the same picture at body-text size'],
+    [['Zdob şi Zdub', 'Zdob și Zdub'], [true, true],
+        'same, mid-string'],
+    [['Ștefan Hrușcă', 'Stefan Hrusca', 'Ştefan Hruşcă'], [true, false, true],
+        'three-way: the two marked rows are confusable, the bare one is not'],
+    [['Motörhead', 'Motorhead'], [false, false],
+        'obvious at a glance, and the umlaut is the actual name - no chip'],
+    [['Șuie Paparude', 'Suie Paparude'], [false, false],
+        'mark vs bare letter is visible'],
+    [['Naive', 'Naïve'], [false, false],
+        'same, and a reminder that character class is not the criterion'],
+    [['Song for the Dead', 'Song for the Deaf'], [false, false],
+        'different letters entirely, no marks involved'],
+];
+
 // Cases that behave wrongly today and have deliberately not been fixed.
 // Reported, visible, never fatal. The 4th field is what CORRECT behaviour would
 // be, so this list covers both directions: pairs that should merge and don't,
@@ -176,8 +209,6 @@ const KEY_MUST_NOT_BE = [
 // runner says so - promote it to MUST_MERGE or MUST_NOT_MERGE.
 const KNOWN_MISS = [
     // --- scoped for v0.6.1, expected to flip as items land ---
-    ['artist', 'Motörhead', 'Motorhead', true,
-        'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
 
     // --- no viable detector, not scoped to any release (DESIGN.md 3.7) ---
     ['track',  'Cartoons and Macramé Wounds', 'Cartoons and Macreme Wounds', true,
@@ -216,6 +247,14 @@ KEY_MUST_NOT_BE.forEach(([field, input, forbidden, why]) => {
     else passed++;
 });
 
+const chipFailures = [];
+CHIP_EXPECT.forEach(([names, expected, why]) => {
+    const got = confusableMarkChars(names).map(chips => chips.length > 0);
+    const ok = got.length === expected.length && got.every((g, i) => g === expected[i]);
+    if (ok) passed++;
+    else chipFailures.push({ names, expected, got, why });
+});
+
 // KNOWN_MISS is reported, never fatal.
 const fixed = [];
 KNOWN_MISS.forEach(([f, a, b, shouldMatch, why]) => {
@@ -224,7 +263,7 @@ KNOWN_MISS.forEach(([f, a, b, shouldMatch, why]) => {
 
 console.log('\nmerge contract  ' + DIM + '(normalizers read live from index.html)' + OFF + '\n');
 
-const totalFailures = failures.length + keyFailures.length;
+const totalFailures = failures.length + keyFailures.length + chipFailures.length;
 
 if (totalFailures === 0) {
     console.log(`  ${GREEN}PASS${OFF}  ${passed} assertions`);
@@ -240,6 +279,16 @@ if (totalFailures === 0) {
     keyFailures.forEach(f => {
         console.log(`  ${RED}x${OFF} [${f.field}] key guard violated`);
         console.log(`      ${JSON.stringify(f.input)}  ->  ${JSON.stringify(f.got)}  ${RED}(forbidden)${OFF}`);
+        console.log(`      ${DIM}${f.why}${OFF}\n`);
+    });
+    chipFailures.forEach(f => {
+        console.log(`  ${RED}x${OFF} [chip] wrong rows chipped`);
+        f.names.forEach((n, i) => {
+            const want = f.expected[i] ? 'chip' : 'no chip';
+            const got = f.got[i] ? 'chip' : 'no chip';
+            const mark = want === got ? ' ' : RED + '!' + OFF;
+            console.log(`      ${mark} ${JSON.stringify(n)}  want ${want}, got ${got}`);
+        });
         console.log(`      ${DIM}${f.why}${OFF}\n`);
     });
 }

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/*
+ * Merge contract for the Scrobble Analyzer normalizers.
+ *
+ *   node tests/merge-contract.js
+ *
+ * WHAT THIS IS
+ * ------------
+ * A developer-side test. It never ships, never runs in the browser, and has no
+ * effect on index.html - users still download one file. It exists because
+ * normalization changes are the highest-risk edits in the codebase: they
+ * silently change what groups with what, and nothing else makes that visible
+ * before release.
+ *
+ * WHAT IT ASSERTS
+ * ---------------
+ * Grouping, NOT correctness. A MUST_MERGE pair claims two spellings belong on
+ * the same card. It says nothing about which spelling is right - that stays a
+ * human decision (DESIGN.md 1.3). MUST_NOT_MERGE is the mirror: these must stay
+ * on separate cards because they are genuinely different things.
+ *
+ * The MUST_NOT list is the important half. A fix that fails to fix is obvious;
+ * a fix that also quietly merges two distinct artists is the one that corrupts
+ * somebody's triage.
+ *
+ * HOW TO ADD A CASE
+ * -----------------
+ *   1. Add the pair below with its issue number.
+ *   2. Run this. WATCH IT FAIL - that is what proves you reproduced the report.
+ *   3. Change the normalizer in index.html.
+ *   4. Run again: new case passes, nothing in MUST_NOT_MERGE broke.
+ *   5. Commit the contract change and the normalizer change together.
+ *
+ * The normalizers are READ OUT OF index.html at runtime, never copied here. A
+ * copy drifts silently and you end up testing code you are not shipping.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const HTML = path.join(__dirname, '..', 'index.html');
+
+// --- load the real normalizers straight out of index.html --------------------
+function loadNormalizers() {
+    const html = fs.readFileSync(HTML, 'utf8');
+    const names = ['normalizeArtist', 'normalizeAlbum', 'normalizeTrack'];
+    const sources = names.map(name => {
+        const open = `        function ${name}(`;
+        const start = html.indexOf(open);
+        if (start === -1) {
+            throw new Error(
+                `Could not find "function ${name}" at top level in index.html.\n` +
+                `The merge contract requires all three normalizers to be top-level\n` +
+                `functions indented 8 spaces. If one was moved or re-nested, move it\n` +
+                `back - see docs/DESIGN.md 4.1.1.`
+            );
+        }
+        const close = '\n        }\n';
+        const end = html.indexOf(close, start);
+        if (end === -1) throw new Error(`No closing brace found for ${name}`);
+        return html.slice(start, end + close.length);
+    });
+    const factory = new Function(sources.join('\n') + `\nreturn { ${names.join(', ')} };`);
+    return factory();
+}
+
+const { normalizeArtist, normalizeAlbum, normalizeTrack } = loadNormalizers();
+
+const FN = { artist: normalizeArtist, album: normalizeAlbum, track: normalizeTrack };
+
+// --- the contract ------------------------------------------------------------
+// [field, a, b, why]
+
+const MUST_MERGE = [
+    // --- shipped behaviour: these already pass and must keep passing ---
+    ['artist', 'The Beatles',        'Beatles',              'leading "the" is stripped'],
+    ['artist', 'Simon & Garfunkel',  'Simon and Garfunkel',  'ampersand unified on artists'],
+    ['track',  '“Heroes”', '"Heroes"',             'smart double quotes fold to ASCII'],
+    ['track',  'Goin’ Out West', "Goin' Out West",      'smart single quote folds to ASCII'],
+    ['album',  'Aja (Remastered)',   'Aja',                  'edition suffix stripped'],
+    ['track',  'Midtown - Remaster', 'Midtown',              'dash remaster suffix stripped'],
+    ['track',  'Midtown (Instrumental)', 'Midtown',          'parenthetical keyword stripped'],
+];
+
+const MUST_NOT_MERGE = [
+    // --- the canonical guard: different credits, correctly distinct ---
+    ['artist', 'Elvis Costello', 'Elvis Costello & The Attractions', 'different credits (DESIGN.md 1.7)'],
+    ['artist', 'Albert Hammond', 'Albert Hammond, Jr.',              'father and son, different artists'],
+
+    // --- near-miss titles that edit distance would wrongly merge (DESIGN.md 3.7) ---
+    ['track',  'Song for the Dead', 'Song for the Deaf', 'distinct QOTSA tracks, edit distance 1'],
+    ['track',  'Opus 17',           'Opus 37',           'distinct pieces, edit distance 1'],
+    ['track',  'Obstacle 1',        'Obstacle 2',        'distinct Interpol tracks'],
+
+    // --- albums are not artists: no leading-"the" strip here ---
+    ['album',  'The Wall',          'Wall',              'leading "the" is meaningful in album titles'],
+];
+
+// Assertions about a single key, not a pair.
+//
+// Some guards cannot be expressed as a pair, because the string you are
+// guarding against is itself rewritten by the normalizer. The 3.15.20 guard is
+// the case in point: asserting that "3.15.20" and "31520" stay unmerged proves
+// nothing, since the year rule chews "31520" down to "3" and they differ no
+// matter what punctuation does. The real requirement is about the key itself.
+//
+// [field, input, forbidden key, why]
+const KEY_MUST_NOT_BE = [
+    ['track', '3.15.20', '31520',
+        'DESIGN.md 1.7 title guard: punctuation must map to a SPACE, never be ' +
+        'deleted. If this fires, a rule is deleting "." instead of replacing it.'],
+    ['album', '3.15.20', '31520', 'same guard on the album normalizer'],
+];
+
+// Cases that behave wrongly today and have deliberately not been fixed.
+// Reported, visible, never fatal. The 4th field is what CORRECT behaviour would
+// be, so this list covers both directions: pairs that should merge and don't,
+// and pairs that shouldn't merge but do. When one starts behaving correctly the
+// runner says so - promote it to MUST_MERGE or MUST_NOT_MERGE.
+const KNOWN_MISS = [
+    // --- scoped for v0.6.1, expected to flip as items land ---
+    ['artist', 'Albert Hammond, Jr.', 'Albert Hammond Jr', true,
+        'issue #11 - punctuation not stripped yet (v0.6.1 item 3)'],
+    ['artist', 'Motörhead', 'Motorhead', true,
+        'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
+    ['track',  '9th & Hennepin', '9th and Hennepin', true,
+        'discussion #10 - no ampersand rule on tracks yet (v0.6.1 item 5)'],
+    ['track',  'Young Love [ft. Laura Marling]', 'Young Love (feat. Laura Marling)', true,
+        'issue #17 - feat/ft not in the track keyword list yet (v0.6.1 item 2)'],
+    ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', true,
+        'issue #17 - bracket/paren containers not canonicalised yet (v0.6.1 item 7)'],
+    ['track',  'Someone´s in the Wolf', "Someone's in the Wolf", true,
+        'issue #12 - U+00B4 not in the apostrophe class yet (v0.6.1 item 6)'],
+
+    // --- no viable detector, not scoped to any release (DESIGN.md 3.7) ---
+    ['track',  'Cartoons and Macramé Wounds', 'Cartoons and Macreme Wounds', true,
+        'issue #15 - a typo, not an accent; edit distance is not usable'],
+    ['track',  'Citizen Erased', 'Citzen Erased', true,
+        'issue #16 - single-character typo; edit distance is not usable'],
+
+    // --- found 2026-08-01 while writing this contract, not yet triaged ---
+    ['track',  'Midtown - 2023 Remaster', 'Midtown', true,
+        'dangling separator: "X - YYYY Remaster" leaves "x -" because the dash rule ' +
+        'needs the keyword immediately after the dash, so the year rule strips the ' +
+        'year and leaves the dash behind. Common Spotify format (disc. #7).'],
+    ['track',  '19-2000', '19-2001', false,
+        'over-eager year strip: the trailing \\d{4} rule eats part of a legitimate ' +
+        'title, so both collapse to "19-". Same for Lorn "555-5555" -> "555-".'],
+];
+
+// --- runner ------------------------------------------------------------------
+const GREEN = '\x1b[32m', RED = '\x1b[31m', DIM = '\x1b[2m', YEL = '\x1b[33m', OFF = '\x1b[0m';
+
+let passed = 0;
+const failures = [];
+
+function check(field, a, b, why, shouldMatch) {
+    const fn = FN[field];
+    if (!fn) throw new Error('unknown field: ' + field);
+    const ka = fn(a), kb = fn(b);
+    const matched = ka === kb;
+    if (matched === shouldMatch) {
+        passed++;
+        return true;
+    }
+    failures.push({ field, a, b, why, ka, kb, shouldMatch });
+    return false;
+}
+
+MUST_MERGE.forEach(([f, a, b, why]) => check(f, a, b, why, true));
+MUST_NOT_MERGE.forEach(([f, a, b, why]) => check(f, a, b, why, false));
+
+const keyFailures = [];
+KEY_MUST_NOT_BE.forEach(([field, input, forbidden, why]) => {
+    const got = FN[field](input);
+    if (got === forbidden) keyFailures.push({ field, input, forbidden, why, got });
+    else passed++;
+});
+
+// KNOWN_MISS is reported, never fatal.
+const fixed = [];
+KNOWN_MISS.forEach(([f, a, b, shouldMatch, why]) => {
+    if ((FN[f](a) === FN[f](b)) === shouldMatch) fixed.push({ f, a, b, shouldMatch, why });
+});
+
+console.log('\nmerge contract  ' + DIM + '(normalizers read live from index.html)' + OFF + '\n');
+
+const totalFailures = failures.length + keyFailures.length;
+
+if (totalFailures === 0) {
+    console.log(`  ${GREEN}PASS${OFF}  ${passed} assertions`);
+} else {
+    console.log(`  ${RED}FAIL${OFF}  ${totalFailures} of ${passed + totalFailures} assertions\n`);
+    failures.forEach(f => {
+        const verb = f.shouldMatch ? 'should have merged, did not' : 'must NOT merge, but did';
+        console.log(`  ${RED}x${OFF} [${f.field}] ${verb}`);
+        console.log(`      ${JSON.stringify(f.a)}  ->  ${JSON.stringify(f.ka)}`);
+        console.log(`      ${JSON.stringify(f.b)}  ->  ${JSON.stringify(f.kb)}`);
+        console.log(`      ${DIM}${f.why}${OFF}\n`);
+    });
+    keyFailures.forEach(f => {
+        console.log(`  ${RED}x${OFF} [${f.field}] key guard violated`);
+        console.log(`      ${JSON.stringify(f.input)}  ->  ${JSON.stringify(f.got)}  ${RED}(forbidden)${OFF}`);
+        console.log(`      ${DIM}${f.why}${OFF}\n`);
+    });
+}
+
+if (KNOWN_MISS.length) {
+    console.log(`\n  ${DIM}${KNOWN_MISS.length} known misses not yet fixed (not failures)${OFF}`);
+}
+if (fixed.length) {
+    console.log(`\n  ${YEL}!${OFF} ${fixed.length} KNOWN_MISS case(s) now behave correctly - promote them:`);
+    fixed.forEach(f => {
+        const target = f.shouldMatch ? 'MUST_MERGE' : 'MUST_NOT_MERGE';
+        console.log(`      [${f.f}] -> ${target}  ${JSON.stringify(f.a)} / ${JSON.stringify(f.b)}`);
+        console.log(`          ${DIM}${f.why}${OFF}`);
+    });
+}
+
+console.log('');
+process.exit(totalFailures ? 1 : 0);

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -87,6 +87,16 @@ const MUST_MERGE = [
     ['track',  'Midtown - 2023 Remaster', 'Midtown',         'dangling separator (disc. #7 Spotify shape)'],
     ['track',  'Always Then - 2017 Version', 'Always Then',  'same, with "version"'],
     ['album',  'Aja - 1999 Remaster', 'Aja',                 'same rule on the album normalizer'],
+
+    // --- v0.6.1 item 2: featured-artist parentheticals ---
+    ['track',  'Young Love [ft. Laura Marling]', 'Young Love (feat. Laura Marling)',
+        'issue #17 - ft. and feat. both stripped, so container type stops mattering'],
+    ['track',  'A Real Hero (feat. Electric Youth)', 'A Real Hero',
+        'discussion #4 - featured artist in the title'],
+    ['track',  'Cruel Intentions (featuring Beth Ditto)', 'Cruel Intentions',
+        '"featuring" spelled out - feat(uring)? is one token'],
+    ['track',  'Machina (feat. Mariana Saldaña)', 'Machina (ft. Mariana Saldaña)',
+        'the two abbreviations agree with each other'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -107,6 +117,13 @@ const MUST_NOT_MERGE = [
     ['track',  '1991',              '1983',              'numeric titles both became "" and wrongly merged'],
     ['track',  '80186',             '80286',             'trailing \\d{4} matched inside a 5-digit title'],
     ['track',  '555-5555',          '555-1234',          'Lorn - phone-number titles must stay distinct'],
+
+    // --- v0.6.1 item 2: "ft" must not match inside ordinary words. These are
+    //     real titles from a real library that a boundary-less \bft\b eats. ---
+    ['track',  'Quattro (World Drifts In)',            'Quattro',            '"ft" inside "Drifts"'],
+    ['track',  'Debase (Soft Palate)',                 'Debase',             '"ft" inside "Soft"'],
+    ['track',  'Winter (What We Never Were After All)','Winter',             '"ft" inside "After"'],
+    ['track',  'Mars and the Artist (after Cy Twombly)','Mars and the Artist','"ft" inside "after"'],
 ];
 
 // Assertions about a single key, not a pair.
@@ -138,8 +155,6 @@ const KNOWN_MISS = [
         'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
     ['track',  '9th & Hennepin', '9th and Hennepin', true,
         'discussion #10 - no ampersand rule on tracks yet (v0.6.1 item 5)'],
-    ['track',  'Young Love [ft. Laura Marling]', 'Young Love (feat. Laura Marling)', true,
-        'issue #17 - feat/ft not in the track keyword list yet (v0.6.1 item 2)'],
     ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', true,
         'issue #17 - bracket/paren containers not canonicalised yet (v0.6.1 item 7)'],
     ['track',  'Someone´s in the Wolf', "Someone's in the Wolf", true,

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -97,6 +97,16 @@ const MUST_MERGE = [
         '"featuring" spelled out - feat(uring)? is one token'],
     ['track',  'Machina (feat. Mariana Saldaña)', 'Machina (ft. Mariana Saldaña)',
         'the two abbreviations agree with each other'],
+
+    // --- v0.6.1 item 3: punctuation to a space ---
+    ['artist', 'Albert Hammond, Jr.', 'Albert Hammond Jr',  'issue #11'],
+    ['artist', 'T. Rex',              'T.Rex',              'spacing around an initial'],
+    ['artist', 'Peter, Bjorn and John','Peter Bjorn and John','serial comma in a band name'],
+    ['track',  'D.A.N.C.E.',          'D.A.N.C.E',          'trailing period only'],
+    ['track',  'Blvd. Nights',        'Blvd Nights',        'abbreviation period'],
+    ['track',  'You, Appearing',      'You Appearing',      'comma to a space, not to nothing'],
+    ['album',  'Endtroducing.....',   'Endtroducing',       'ellipsis run'],
+    ['album',  'Attack, Decay, Sustain, Release', 'Attack Decay Sustain Release', 'serial commas'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -149,8 +159,6 @@ const KEY_MUST_NOT_BE = [
 // runner says so - promote it to MUST_MERGE or MUST_NOT_MERGE.
 const KNOWN_MISS = [
     // --- scoped for v0.6.1, expected to flip as items land ---
-    ['artist', 'Albert Hammond, Jr.', 'Albert Hammond Jr', true,
-        'issue #11 - punctuation not stripped yet (v0.6.1 item 3)'],
     ['artist', 'Motörhead', 'Motorhead', true,
         'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
     ['track',  '9th & Hennepin', '9th and Hennepin', true,

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -82,6 +82,11 @@ const MUST_MERGE = [
     ['album',  'Aja (Remastered)',   'Aja',                  'edition suffix stripped'],
     ['track',  'Midtown - Remaster', 'Midtown',              'dash remaster suffix stripped'],
     ['track',  'Midtown (Instrumental)', 'Midtown',          'parenthetical keyword stripped'],
+
+    // --- v0.6.1 item 9: year between the dash and the keyword ---
+    ['track',  'Midtown - 2023 Remaster', 'Midtown',         'dangling separator (disc. #7 Spotify shape)'],
+    ['track',  'Always Then - 2017 Version', 'Always Then',  'same, with "version"'],
+    ['album',  'Aja - 1999 Remaster', 'Aja',                 'same rule on the album normalizer'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -96,6 +101,12 @@ const MUST_NOT_MERGE = [
 
     // --- albums are not artists: no leading-"the" strip here ---
     ['album',  'The Wall',          'Wall',              'leading "the" is meaningful in album titles'],
+
+    // --- v0.6.1 item 10: a bare trailing number is part of the title ---
+    ['track',  '19-2000',           '19-2001',           'year rule must not eat digits belonging to the title'],
+    ['track',  '1991',              '1983',              'numeric titles both became "" and wrongly merged'],
+    ['track',  '80186',             '80286',             'trailing \\d{4} matched inside a 5-digit title'],
+    ['track',  '555-5555',          '555-1234',          'Lorn - phone-number titles must stay distinct'],
 ];
 
 // Assertions about a single key, not a pair.
@@ -140,14 +151,6 @@ const KNOWN_MISS = [
     ['track',  'Citizen Erased', 'Citzen Erased', true,
         'issue #16 - single-character typo; edit distance is not usable'],
 
-    // --- found 2026-08-01 while writing this contract, not yet triaged ---
-    ['track',  'Midtown - 2023 Remaster', 'Midtown', true,
-        'dangling separator: "X - YYYY Remaster" leaves "x -" because the dash rule ' +
-        'needs the keyword immediately after the dash, so the year rule strips the ' +
-        'year and leaves the dash behind. Common Spotify format (disc. #7).'],
-    ['track',  '19-2000', '19-2001', false,
-        'over-eager year strip: the trailing \\d{4} rule eats part of a legitimate ' +
-        'title, so both collapse to "19-". Same for Lorn "555-5555" -> "555-".'],
 ];
 
 // --- runner ------------------------------------------------------------------

--- a/tests/merge-contract.js
+++ b/tests/merge-contract.js
@@ -119,6 +119,11 @@ const MUST_MERGE = [
     ['track',  'She Don`t Use Jelly',    "She Don't Use Jelly",    'U+0060 backtick'],
     ['track',  'Love Ainʼt No Stranger', "Love Ain't No Stranger", 'U+02BC modifier-letter apostrophe'],
     ['track',  'Goin’ Out West',         "Goin' Out West",         'U+2019, unchanged by this item'],
+
+    // --- v0.6.1 item 7: [ ] and ( ) are interchangeable ---
+    ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', 'issue #17, the general class'],
+    ['track',  'Track [Interlude]',    'Track (Interlude)',    'no keyword inside, so only the container differs (DESIGN.md 3.6)'],
+    ['album',  'Noise [Reprise]',      'Noise (Reprise)',       'the rule reaches albums too'],
 ];
 
 const MUST_NOT_MERGE = [
@@ -173,8 +178,6 @@ const KNOWN_MISS = [
     // --- scoped for v0.6.1, expected to flip as items land ---
     ['artist', 'Motörhead', 'Motorhead', true,
         'issue #14 - diacritics not folded yet (v0.6.1 item 4)'],
-    ['track',  'Ramalama [Bang Bang]', 'Ramalama (Bang Bang)', true,
-        'issue #17 - bracket/paren containers not canonicalised yet (v0.6.1 item 7)'],
 
     // --- no viable detector, not scoped to any release (DESIGN.md 3.7) ---
     ['track',  'Cartoons and Macramé Wounds', 'Cartoons and Macreme Wounds', true,


### PR DESCRIPTION
Theme: **the normalizer catches what you reported.** Ten scoped items, one commit each, every one measured before it landed.

## Measured impact

Working tree vs `main`, at the thresholds as shipped (artist ≥10 plays, album ≥5, track ≥3), against two independent libraries:

| | scoblitz (160,742 scrobbles) | Maeldun (380,877 scrobbles) |
|---|---|---|
| Artist | 46 → **49** | 38 → **49** |
| Album | 98 → **132** | 31 → **55** |
| Track | 994 → **1201** | 400 → **559** |
| Groups genuinely dropped | **0** | 6, all intentional |

Every disappearing group was classified rather than counted — scoblitz 42 gone / 42 absorbed into larger groups / 0 dropped; Maeldun 10 gone / 4 absorbed / 6 dropped. Those six are the numeric-title false positives item 10 exists to remove (Crystal Castles `1991`/`1983`, HEALTH `0001`–`0004`, MASTER BOOT RECORD `80186`–`80686` — all genuinely distinct tracks the old rule collapsed by deleting the entire title).

Dismissal orphaning stays negligible on both libraries: 0 artist and 0 album top-names change, 10 of 2,229 track members on scoblitz. No migration needed.

## What changed

| # | Item | Closes |
|---|---|---|
| 1 | Hoist the three normalizers + merge contract | infrastructure |
| 2 | `feat`/`ft` stripped from track parentheticals | #17, part of #4 |
| 3 | Punctuation → space, all three normalizers | #11 |
| 4 | Diacritic folding + confusable-character chip | #14 |
| 5 | `&`/`and` unified on tracks and albums | discussion #10 |
| 6 | Apostrophe class widened to U+00B4, U+0060, U+02BC | #12 |
| 7 | Square brackets canonicalised to parentheses | #17, general class |
| 8 | Android file-input `accept` list | #5 (unverified — see below) |
| 9 | Year allowed between dash and keyword | found by the contract |
| 10 | Bare trailing year handled correctly | found by the contract |

## Three things worth reviewing closely

**The merge contract earned its keep before any scoped item was written.** `tests/merge-contract.js` is a plain Node script, no dependencies, that reads the normalizers out of `index.html` at runtime rather than copying them. Writing MUST_MERGE cases for behaviour assumed to already work surfaced items 9 and 10 — the second of which was not merely failing to group but *fabricating cards*. It now stands at 85 assertions with 2 known misses (the typo cases #15/#16, which have no viable detector — see DESIGN.md §3.7 for why edit distance is unusable: 1,617 distance-1 pairs, dominated by genuinely distinct tracks like `Song for the Dead`/`Song for the Deaf`).

**Item 4 is the only UI work.** Folding diacritics creates a card the tool has never produced before — groups whose rows are the same picture. Four of the eight new artist groups on Maeldun's library are Romanian comma-below vs cedilla (U+0219 vs U+015F), which are indistinguishable at body-text size. The chip fires on a perceptual test, not a character class: mark-vs-different-mark gets one, mark-vs-bare-letter does not. So `Subcarpați` chips and `Motörhead` does not, and that asymmetry is deliberate — the umlaut is the band's actual name, and chipping it would imply the ASCII spelling is the corrected one.

**One library was not enough.** Item 10's first form passed cleanly on 381k scrobbles and broke `Comfortably Numb`/`Comfortably Numb 2022`, which only exists in the other library. The refined rule has three conditions, each guarding a specific failure, and all three are pinned by tests. DESIGN.md §4.1.3 records this: a normalizer change validated against a single export is undertested. Both exports are now the standing validation set — which matters most for the v0.7 ampersand-drop work, where overmerge risk is far higher than anything here.

## Before tagging a release

- **Issue #5 is unverified.** I cannot test on a Pixel, and the original report was never reproduced on your own Pixel 8a — the reporter never followed up with the detail that was asked for. The change is the standard fix for the described symptom, not a confirmed one. Deliberately **not** written as a closing keyword; worth asking @DavidVI18 to retest first.
- The `⚠️ smart quote` label became a misnomer once the character class grew, and is resolved in this branch (`934ad68`): both look-alike cases now name the character and its code point rather than a category, so the label cannot go stale again.

## Verification

- Merge contract: 85 assertions, run against the shipped functions
- Both guards tested by injecting the exact bug they exist to catch, and confirming failure — twice this caught a *test* that restated what it was meant to pin rather than discovering it (the `3.15.20` guard and the chip drift guard)
- Hoist proven behaviour-neutral: 90,731 key comparisons before/after, zero mismatches
- Chip rendering confirmed in a browser against synthetic exports, no console errors
- `node --check` on the inline script after every change

Closes #11
Closes #12
Closes #14
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
